### PR TITLE
Summary report: add 'Avg Records'

### DIFF
--- a/include/flb_report.h
+++ b/include/flb_report.h
@@ -41,6 +41,7 @@ struct flb_report {
     /* General stats */
     size_t sum_bytes;    /* Total number of bytes */
     size_t sum_mem;      /* total number of bytes reported per snapshot */
+    size_t sum_records;  /* total number of log records */
     int sum_cpu_count;   /* CPU snapshots summarized */
     double sum_cpu;      /* total %CPU usage */
     double sum_duration; /* total elapsed time of tests */

--- a/src/flb-tail-writer.c
+++ b/src/flb-tail-writer.c
@@ -290,7 +290,7 @@ static int run_fs_writer(pid_t pid,
             flb_proc_stat_destroy(t2);
 
         }
-
+        r->sum_records = total_records;
         flb_report_summary(r);
     }
 

--- a/src/flb-tcp-writer.c
+++ b/src/flb-tcp-writer.c
@@ -378,7 +378,7 @@ static int run_tcp_writer(pid_t pid,
             flb_proc_stat_destroy(t2);
 
         }
-
+        r->sum_records = total_records;
         flb_report_summary(r);
     }
 

--- a/src/flb_report.c
+++ b/src/flb_report.c
@@ -112,6 +112,7 @@ struct flb_report *flb_report_create(char *out, int format, int pid, int wait)
     r->sum_bytes = 0;
     r->sum_mem = 0;
     r->sum_cpu = 0.0;
+    r->sum_records = 0;
 
     if (r->pid >= 0) {
         t = flb_proc_stat_create(r->pid);
@@ -240,6 +241,9 @@ int flb_report_summary(struct flb_report *r)
 
     tmp = flb_report_human_readable_size(r->sum_bytes / r->sum_duration);
     dprintf(r->fd, "  - Avg Rate    : %s/sec\n", tmp);
+    tmp = flb_report_human_readable_size(r->sum_records / r->sum_duration);
+    dprintf(r->fd, "  - Avg Records : %s/sec\n", tmp);
+
     free(tmp);
 }
 


### PR DESCRIPTION
New Summary Output:

- Summary
  - Process     : fluent-bit
  - PID         : 8
  - Elapsed Time: 68.36 seconds
  - Avg Memory  : 70.72M
  - Avg CPU     : 70.54%
  - Avg Rate    : 81.25M/sec
  - Avg Records : 82.11K/sec

Signed-off-by: Michael Voelker <novecento@gmx.de>